### PR TITLE
Fix bootstrap cluster path resolution

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-BASEPATH="../clusters/"
-CLUSTER="$1"  
-CLUSTER_PATH="${BASEPATH}${CLUSTER}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLUSTERS_ROOT="$SCRIPT_DIR/../clusters"
+CLUSTER="$1"
+CLUSTER_PATH="${CLUSTERS_ROOT}/${CLUSTER}"
 
 echo "🚀 Installing Cert Manager"
 kustomize build --enable-helm "$CLUSTER_PATH"/cert-manager | kubectl apply -f -


### PR DESCRIPTION
## Summary
- resolve clusters directory relative to script location in bootstrap

## Testing
- `bash -n scripts/bootstrap.sh`
- `apt-get update` *(fails: The repository is not signed; 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896896356cc8322b848ab9db63ced2b